### PR TITLE
Fix double navigation

### DIFF
--- a/src/components/router/router.ts
+++ b/src/components/router/router.ts
@@ -29,6 +29,11 @@ export default class Router {
     this.handler.navigate(url);
   }
 
+  public setHref(newUrlHashPath: string) {
+    const href = `${window.location.href.replace(/#(.*)$/, '')}#${newUrlHashPath}`;
+    window.location.href = href;
+  }
+
   private urlChangedHandler(requestParams: RequestParams) {
     const newPath = requestParams.resource === '' ? requestParams.path : `${requestParams.path}/${ITEM_ID}`;
     const route = this.routes.find((item) => item.path === newPath);

--- a/src/components/view/page/catalog-view/catalog-view.ts
+++ b/src/components/view/page/catalog-view/catalog-view.ts
@@ -66,7 +66,9 @@ export default class CatalogView extends DefaultView {
   private createProductLinks(products: Product[]) {
     products.forEach((product) => {
       if (product.key) {
-        const link = new LinkButton(product.key, () => this.router.navigate(`${PagePath.CATALOG}/${product.key}`));
+        const link = new LinkButton(product.key, () => {
+          this.router.setHref(`${PagePath.CATALOG}/${product.key}`);
+        });
         this.wrapper.append(link.getElement());
 
         // const card = new ProductCard(product.key, this.router);

--- a/src/components/view/page/header-view/header-view.ts
+++ b/src/components/view/page/header-view/header-view.ts
@@ -26,7 +26,6 @@ export default class HeaderView extends DefaultView {
     super(params);
 
     this.observer = Observer.getInstance();
-    // this.observer.subscribe(EventName.LOGIN, this.updateHeader.bind(this));
 
     this.headerLinks = new Map();
 
@@ -70,8 +69,10 @@ export default class HeaderView extends DefaultView {
     const title = LinkName.INDEX;
     const route = this.getRoute(path);
     if (route) {
-      const link = new LinkButton(title, () => this.router.navigate(path));
-      this.headerLinks.set(LinkName.INDEX, link);
+      const link = new LinkButton(title, () => {
+        this.router.setHref(path);
+      });
+      this.headerLinks.set(title, link);
       parentElement.append(link.getElement());
     }
   }
@@ -82,8 +83,10 @@ export default class HeaderView extends DefaultView {
     const title = LinkName.CATALOG;
     const route = this.getRoute(path);
     if (route) {
-      const link = new LinkButton(title, () => this.router.navigate(path));
-      this.headerLinks.set(LinkName.CATALOG, link);
+      const link = new LinkButton(title, () => {
+        this.router.setHref(path);
+      });
+      this.headerLinks.set(title, link);
 
       parentElement.append(link.getElement());
     }
@@ -95,8 +98,10 @@ export default class HeaderView extends DefaultView {
     const title = LinkName.LOGIN;
     const route = this.getRoute(path);
     if (route) {
-      const link = new LinkButton(title, () => this.router.navigate(path));
-      this.headerLinks.set(LinkName.LOGIN, link);
+      const link = new LinkButton(title, () => {
+        this.router.setHref(path);
+      });
+      this.headerLinks.set(title, link);
 
       this.observer.subscribe(EventName.LOGIN, () => link.hideButton());
       this.observer.subscribe(EventName.LOGOUT, () => link.showButton());
@@ -111,8 +116,10 @@ export default class HeaderView extends DefaultView {
     const title = LinkName.REGISTRATION;
     const route = this.getRoute(path);
     if (route) {
-      const link = new LinkButton(title, () => this.router.navigate(path));
-      this.headerLinks.set(LinkName.REGISTRATION, link);
+      const link = new LinkButton(title, () => {
+        this.router.setHref(path);
+      });
+      this.headerLinks.set(title, link);
 
       this.observer.subscribe(EventName.LOGIN, () => link.hideButton());
       this.observer.subscribe(EventName.LOGOUT, () => link.showButton());
@@ -126,7 +133,7 @@ export default class HeaderView extends DefaultView {
     const link = new LinkButton(LinkName.LOGOUT, () => {
       this.observer.notify(EventName.LOGOUT);
       localStorage.setItem(`isLogin`, 'false');
-      this.router.navigate('');
+      this.router.setHref('');
     });
 
     this.observer.subscribe(EventName.LOGIN, () => link.showButton());
@@ -138,7 +145,7 @@ export default class HeaderView extends DefaultView {
   private createProfileButton(parent: ElementCreator) {
     const parentElement = parent.getElement();
     const link = new LinkButton(LinkName.PROFILE, () => {
-      this.router.navigate(PagePath.PROFILE);
+      this.router.setHref(PagePath.PROFILE);
     });
 
     this.observer.subscribe(EventName.LOGIN, () => link.showButton());


### PR DESCRIPTION
1. Task: [eCommerce Application](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md)
2. Deploy: [The Best Store](https://makaevaelena.github.io/best_games/sprint_3/#)

  - [x] исправил двойной переход на страницу при использовании метода `router.navigate(url)` путем замены на метод `router.setHref(hashUrl)`
Первый переход происходил при изменении непосредственно href непосредственно в методе `router.navigate(url)`, второй - после "отлова" события hashchanged
![image](https://github.com/MakaevaElena/eCommerce-Application/assets/52540855/c31292cc-e62c-46e1-a8e8-733d29275244)

Изменил в представлениях header и catalog.
Желательно заменить методы на разработанных страницах также.


